### PR TITLE
Set up VMEStream to compile in its new location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ Release/
 *.elf.check
 
 .DS_Store
+*.swp

--- a/VMEStream/Makefile
+++ b/VMEStream/Makefile
@@ -1,7 +1,7 @@
-SOFTDIR=/afs/cern.ch/user/d/dbelknap/softipbus
+SOFTDIR=$(HOME)/trigger_code/softipbus
 
-CFLAGS:=-g -Wall -Iinclude -I$(SOFTDIR)/include -I/opt/xdaq/include/ 
-CXXFLAGS:=$(CFLAGS) -DLINUX
+CFLAGS:=-g -Wall -Iinclude -I$(SOFTDIR)/include -I/opt/xdaq/include/ -std=c99
+CXXFLAGS:=-g -Wall -Iinclude -I$(SOFTDIR)/include -I/opt/xdaq/include/ -DLINUX -DLOG_LEVEL=0x0
 LDFLAGS:=-L/opt/xdaq/lib/ -lCAENVME -llog4cplus
 CC=gcc
 CXX=g++
@@ -9,7 +9,12 @@ CXX=g++
 SRC:=$(wildcard src/vmestream/*.c) \
 	$(wildcard src/vmestream/*.cc) \
 	$(SOFTDIR)/src/circular_buffer.c \
-	$(SOFTDIR)/src/buffer.c
+	$(SOFTDIR)/src/buffer.c \
+	$(SOFTDIR)/src/bytebuffer.c \
+	$(SOFTDIR)/src/transactionhandler.c \
+	$(SOFTDIR)/src/serialization.c \
+	$(SOFTDIR)/src/handlers.c \
+	$(SOFTDIR)/src/testmembase.c
 
 OBJ:=$(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(SRC)))
 
@@ -22,12 +27,12 @@ TEST_SRC:=$(wildcard tests/*_tests.c)
 TESTS:=$(patsubst %.c,%,$(TEST_SRC))
 SH_TESTS:=$(wildcard tests/*_tests.sh)
 
-all : $(LIB) $(EXEC) tests
+all : $(EXEC)
 
 bin/% : $(LIB)
 bin/% : src/%.cc
 	@mkdir -p bin
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $< $(LIB)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $< $(SRC)
 
 $(LIB) : CFLAGS += -fPIC
 $(LIB) : $(OBJ)

--- a/VMEStream/Makefile
+++ b/VMEStream/Makefile
@@ -1,20 +1,18 @@
-SOFTDIR=$(HOME)/trigger_code/softipbus
-
-CFLAGS:=-g -Wall -Iinclude -I$(SOFTDIR)/include -I/opt/xdaq/include/ -std=c99
-CXXFLAGS:=-g -Wall -Iinclude -I$(SOFTDIR)/include -I/opt/xdaq/include/ -DLINUX -DLOG_LEVEL=0x0
+CFLAGS:=-g -Wall -Iinclude -I$(SOFTIPBUS)/include -I/opt/xdaq/include/ -std=c99
+CXXFLAGS:=-g -Wall -Iinclude -I$(SOFTIPBUS)/include -I/opt/xdaq/include/ -DLINUX -DLOG_LEVEL=0x0
 LDFLAGS:=-L/opt/xdaq/lib/ -lCAENVME -llog4cplus
 CC=gcc
 CXX=g++
 
 SRC:=$(wildcard src/vmestream/*.c) \
 	$(wildcard src/vmestream/*.cc) \
-	$(SOFTDIR)/src/circular_buffer.c \
-	$(SOFTDIR)/src/buffer.c \
-	$(SOFTDIR)/src/bytebuffer.c \
-	$(SOFTDIR)/src/transactionhandler.c \
-	$(SOFTDIR)/src/serialization.c \
-	$(SOFTDIR)/src/handlers.c \
-	$(SOFTDIR)/src/testmembase.c
+	$(SOFTIPBUS)/src/circular_buffer.c \
+	$(SOFTIPBUS)/src/buffer.c \
+	$(SOFTIPBUS)/src/bytebuffer.c \
+	$(SOFTIPBUS)/src/transactionhandler.c \
+	$(SOFTIPBUS)/src/serialization.c \
+	$(SOFTIPBUS)/src/handlers.c \
+	$(SOFTIPBUS)/src/testmembase.c
 
 OBJ:=$(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(SRC)))
 
@@ -29,8 +27,12 @@ SH_TESTS:=$(wildcard tests/*_tests.sh)
 
 all : $(EXEC)
 
+ifndef SOFTIPBUS
+	$(error ERROR: SOFTIPBUS is not set)
+endif
+
 bin/% : $(LIB)
-bin/% : src/%.cc
+bin/% : src/%.cc $(SRC)
 	@mkdir -p bin
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $< $(SRC)
 

--- a/VMEStream/compile_tmp.sh
+++ b/VMEStream/compile_tmp.sh
@@ -1,9 +1,11 @@
 #!/bin/bash 
 
-export SOFTDIR=${SOFTDIR:-/afs/cern.ch/user/d/dbelknap/softipbus}
+#export SOFTDIR=${SOFTDIR:-/afs/cern.ch/user/d/dbelknap/softipbus}
+export SOFTDIR=$HOME/trigger_code/softipbus
 export FLAGS='-g -Wall -Iinclude -I'$SOFTDIR'/include -I/opt/xdaq/include/ -DLINUX'
 export LDFLAGS='-L/opt/xdaq/lib/ -lCAENVME -llog4cplus'
 
+mkdir -p bin
 g++ -o bin/vme2fd $FLAGS $LDFLAGS -DLOG_LEVEL=0x0\
   src/vme2fd.cc \
   src/vmestream/caen.cc \
@@ -12,6 +14,6 @@ g++ -o bin/vme2fd $FLAGS $LDFLAGS -DLOG_LEVEL=0x0\
   $SOFTDIR/src/circular_buffer.c $SOFTDIR/src/buffer.c $SOFTDIR/src/bytebuffer.c \
   src/vmestream/OrscEmulator.cc src/vmestream/OrscEchoEmulator.cc \
   src/vmestream/OrscIpbusEmulator.cc \
-  ../softipbus/src/transactionhandler.c \
-  ../softipbus/src/serialization.c ../softipbus/src/handlers.c \
-  ../softipbus/src/testmembase.c
+  $SOFTDIR/src/transactionhandler.c \
+  $SOFTDIR/src/serialization.c $SOFTDIR/src/handlers.c \
+  $SOFTDIR/src/testmembase.c

--- a/VMEStream/src/vme2fd.cc
+++ b/VMEStream/src/vme2fd.cc
@@ -28,7 +28,7 @@
 
 #define MIN(x, y) ( (x) < (y) ? (x) : (y) )
 
-
+// VME RAM holds 512 words
 const uint32_t MAXRAM = 512;
 
 
@@ -73,14 +73,14 @@ int main ( int argc, char** argv )
 
         vme->read(VME_TX_SIZE_ADDR, DATAWIDTH, &vme_tx_size);
         if (vme_tx_size == 0 && *(stream->tx_size) > 0) {
-            vme->write(VME_TX_DATA_ADDR, *(stream->tx_size), stream->tx_data);
+            vme->write(VME_TX_DATA_ADDR, DATAWIDTH, stream->tx_data);
             vme->write(VME_TX_SIZE_ADDR, DATAWIDTH, stream->tx_size);
             *(stream->tx_size) = 0;
         }
 
         vme->read(VME_RX_SIZE_ADDR, DATAWIDTH, &vme_rx_size);
         if (vme_rx_size > 0 && *(stream->rx_size) == 0) {
-            vme->read(VME_RX_DATA_ADDR, vme_rx_size, stream->rx_data);
+            vme->read(VME_RX_DATA_ADDR, DATAWIDTH, stream->rx_data);
             *(stream->rx_size) = vme_rx_size;
             uint32_t zero = 0;
             vme->write(VME_RX_SIZE_ADDR, DATAWIDTH, &zero);

--- a/VMEStream/src/vmestream/VMEController.cc
+++ b/VMEStream/src/vmestream/VMEController.cc
@@ -27,6 +27,12 @@ VMEController::getVMEController()
             std::cout << "Emulating oRSC as an IPBus Server" << std::endl;
             return OrscIpbusEmulator::getVMEController();
         }
+        else {
+            std::cerr << "VME_CONTROLLER not set properly!" << std::endl;;
+            std::cerr << 
+                "-> VME_CONTROLLER = [CAEN, TESTECHO, TESTIPBUS]" << std::endl;
+            exit(1);
+        }
     }
 
     return null::getVMEController();

--- a/environment.sh
+++ b/environment.sh
@@ -9,3 +9,9 @@
 
 # Setup an env var pointing to your softipbus installation
 export SOFTIPBUS=$HOME/trigger_code/softipbus
+
+# Include xdaq libraries
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/xdaq/lib
+
+# Run VMEStream in ECHOTEST mode (for now)
+export VME_CONTROLLER=TESTECHO


### PR DESCRIPTION
I modified VMEStream's `Makefile`, `compile_tmp.sh`, and the `environment.sh` script to properly compile and run `vme2fd`. I also switched caen read/write back to using `DATAWIDTH` for the time being.
