### PR TITLE
Use block read/write in vme2fd

### DIFF
--- a/VMEStream/include/OrscEmulator.h
+++ b/VMEStream/include/OrscEmulator.h
@@ -36,6 +36,11 @@ class OrscEmulator : public VMEController
                 unsigned short *data, int dataCounter);
         virtual bool multiwrite(unsigned int *addresses, size_t size,
                 unsigned short *data, int dataCounter);
+        virtual bool block_read(uint32_t address, size_t datawidth,
+                void* buffer, size_t n_bytes);
+        virtual bool block_write(uint32_t address, size_t datawidth,
+                void* buffer, size_t n_bytes);
+
         // does nothing, see subclasses for specific emulation functionality
         virtual void doStuff()=0;
 };

--- a/VMEStream/include/VMEController.h
+++ b/VMEStream/include/VMEController.h
@@ -20,6 +20,8 @@ class VMEController
   virtual bool write(unsigned long address, size_t size, void* value) = 0;
   virtual bool multiread(unsigned int *addresses, size_t size, unsigned short *data, int dataCounter) = 0;
   virtual bool multiwrite(unsigned int *addresses, size_t size, unsigned short *data, int dataCounter) = 0;
+  virtual bool block_read(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes) = 0;
+  virtual bool block_write(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes) = 0;
 
   bool write(unsigned long address, unsigned long value)
     {

--- a/VMEStream/include/caen.h
+++ b/VMEStream/include/caen.h
@@ -19,6 +19,8 @@ class caen : public VMEController
   virtual bool write(unsigned long address, size_t size, void* value);
   virtual bool multiread(unsigned int *addresses, size_t size, unsigned short *data, int dataCounter);
   virtual bool multiwrite(unsigned int *addresses, size_t size, unsigned short *data, int dataCounter);
+  virtual bool block_read(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes);
+  virtual bool block_write(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes);
 
   //MG 4May07
   //long getHandle() {return handle;}

--- a/VMEStream/include/null.h
+++ b/VMEStream/include/null.h
@@ -93,6 +93,31 @@ class null : public VMEController
         return true;
   }
 
+  virtual bool block_read(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes)
+  {
+      Logger logger = Logger::getInstance("VMEController::null");
+
+      static int read_counter = 0;
+      if (read_counter < 10) {
+          LOG4CPLUS_WARN(logger, "null::block_read() called");
+          read_counter++;
+      }
+      return true;
+  }
+
+  virtual bool block_write(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes)
+  {
+      Logger logger = Logger::getInstance("VMEController::null");
+
+      static int read_counter = 0;
+      if (read_counter < 10) {
+          LOG4CPLUS_WARN(logger, "null::block_write() called");
+          read_counter++;
+      }
+      return true;
+  }
+
+
 
  private:
   // Private to make this a singleton

--- a/VMEStream/src/vme2fd.cc
+++ b/VMEStream/src/vme2fd.cc
@@ -71,16 +71,24 @@ int main ( int argc, char** argv )
 
         vmestream_transfer_data(stream);
 
+
         vme->read(VME_TX_SIZE_ADDR, DATAWIDTH, &vme_tx_size);
+
         if (vme_tx_size == 0 && *(stream->tx_size) > 0) {
-            vme->write(VME_TX_DATA_ADDR, DATAWIDTH, stream->tx_data);
+            vme->block_write(VME_TX_DATA_ADDR, DATAWIDTH, stream->tx_data,
+                    *(stream->tx_size) * sizeof(uint32_t));
+
             vme->write(VME_TX_SIZE_ADDR, DATAWIDTH, stream->tx_size);
             *(stream->tx_size) = 0;
         }
 
+
         vme->read(VME_RX_SIZE_ADDR, DATAWIDTH, &vme_rx_size);
+
         if (vme_rx_size > 0 && *(stream->rx_size) == 0) {
-            vme->read(VME_RX_DATA_ADDR, DATAWIDTH, stream->rx_data);
+            vme->block_read(VME_RX_DATA_ADDR, DATAWIDTH, stream->rx_data,
+                    vme_rx_size * sizeof(uint32_t));
+
             *(stream->rx_size) = vme_rx_size;
             uint32_t zero = 0;
             vme->write(VME_RX_SIZE_ADDR, DATAWIDTH, &zero);

--- a/VMEStream/src/vmestream/OrscEmulator.cc
+++ b/VMEStream/src/vmestream/OrscEmulator.cc
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 
 // we use 512 words a time for the RAMS
-#define VMERAMSIZE (512 * sizeof(uint32_t))
+#define VMERAMSIZE 512
 
 OrscEmulator::OrscEmulator()
 {
@@ -36,12 +36,13 @@ OrscEmulator::~OrscEmulator()
 }
 
 
+/**
+ * Emulator read is used only for the size registers
+ */
 bool
 OrscEmulator::read(unsigned long address, size_t size, void* value)
 {
-
-    switch(address)
-    {
+    switch(address) {
         case 0xBEEFCAFE:
             assert(size == 4);
             memcpy(value, &register1, sizeof(uint32_t));
@@ -50,12 +51,6 @@ OrscEmulator::read(unsigned long address, size_t size, void* value)
             assert(size == 4);
             memcpy(value, &register2, sizeof(uint32_t));
             break;
-        case 0xCAFEBABE:
-            memcpy(value, ram1, size * sizeof(uint32_t));
-            break;
-        case 0xFACEFEED:
-            memcpy(value, ram2, size * sizeof(uint32_t));
-            break;
         default:
             return 0;
     }
@@ -63,11 +58,13 @@ OrscEmulator::read(unsigned long address, size_t size, void* value)
 }
 
 
+/**
+ * Emulator write is used only for the size registers
+ */
 bool
 OrscEmulator::write(unsigned long address, size_t size, void* value)
 {
-    switch(address)
-    {
+    switch(address) {
         case 0xBEEFCAFE:
             assert(size == 4);
             memcpy(&register1, value, sizeof(uint32_t));
@@ -75,12 +72,6 @@ OrscEmulator::write(unsigned long address, size_t size, void* value)
         case 0xDEADBEEF:
             assert(size == 4);
             memcpy(&register2, value, sizeof(uint32_t));
-            break;
-        case 0xCAFEBABE:
-            memcpy(ram1, value, size * sizeof(uint32_t));
-            break;
-        case 0xFACEFEED:
-            memcpy(ram2, value, size * sizeof(uint32_t));
             break;
         default:
             return 0;
@@ -106,14 +97,40 @@ OrscEmulator::multiwrite(unsigned int *addresses, size_t size,
 
 
 bool
-OrscEmulator::block_read(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes)
+OrscEmulator::block_read(uint32_t address, size_t datawidth,
+        void* buffer, size_t n_bytes)
 {
+    switch(address) {
+        case 0xCAFEBABE:
+            assert(datawidth == 4);
+            memcpy(buffer, ram1, n_bytes);
+            break;
+        case 0xFACEFEED:
+            assert(datawidth == 4);
+            memcpy(buffer, ram2, n_bytes);
+            break;
+        default:
+            return 0;
+    }
     return 1;
 }
 
 bool
-OrscEmulator::block_write(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes)
+OrscEmulator::block_write(uint32_t address, size_t datawidth,
+        void* buffer, size_t n_bytes)
 {
+    switch(address) {
+        case 0xCAFEBABE:
+            assert(datawidth == 4);
+            memcpy(ram1, buffer, n_bytes);
+            break;
+        case 0xFACEFEED:
+            assert(datawidth == 4);
+            memcpy(ram2, buffer, n_bytes);
+            break;
+        default:
+            return 0;
+    }
     return 1;
 }
 

--- a/VMEStream/src/vmestream/OrscEmulator.cc
+++ b/VMEStream/src/vmestream/OrscEmulator.cc
@@ -104,6 +104,19 @@ OrscEmulator::multiwrite(unsigned int *addresses, size_t size,
     return 1;
 }
 
+
+bool
+OrscEmulator::block_read(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes)
+{
+    return 1;
+}
+
+bool
+OrscEmulator::block_write(uint32_t address, size_t datawidth, void* buffer, size_t n_bytes)
+{
+    return 1;
+}
+
 bool
 OrscEmulator::reset()
 {

--- a/VMEStream/src/vmestream/caen.cc
+++ b/VMEStream/src/vmestream/caen.cc
@@ -274,3 +274,59 @@ caen::multiwrite(unsigned int *addresses, size_t size, unsigned short *data, int
     }
   return true;
 }
+
+
+bool
+caen::block_write(uint32_t address, size_t datawidth,
+        void* buffer, size_t n_bytes)
+{
+    CVAddressModifier am = cvA32_U_DATA;
+    if(type == 0) am = cvA32_S_DATA;
+    else if(type == 1) am = cvA24_S_DATA;
+    else if (type == 2) am = cvA16_S;
+
+    CVDataWidth dw = cvD32;
+    if(datawidth == 1) dw = cvD8;
+    else if(datawidth == 2) dw = cvD16;
+    else if(datawidth == 4) dw = cvD32;
+    else if(datawidth == 8) dw = cvD64;
+
+    int count = 0; // number of byes transferred
+    int status = CAENVME_BLTWriteCycle(handle, address, buffer, n_bytes,
+            am, dw, &count);
+
+    if (status != cvSuccess) {
+        cerr << "CAEN could not write " << hex << address << endl;
+        return false;
+    }
+
+    return true;
+}
+
+
+bool
+caen::block_read(uint32_t address, size_t datawidth,
+        void* buffer, size_t n_bytes)
+{
+    CVAddressModifier am = cvA32_U_DATA;
+    if(type == 0) am = cvA32_S_DATA;
+    else if(type == 1) am = cvA24_S_DATA;
+    else if (type == 2) am = cvA16_S;
+
+    CVDataWidth dw = cvD32;
+    if(datawidth == 1) dw = cvD8;
+    else if(datawidth == 2) dw = cvD16;
+    else if(datawidth == 4) dw = cvD32;
+    else if(datawidth == 8) dw = cvD64;
+
+    int count = 0; // number of byes transferred
+    int status = CAENVME_BLTReadCycle(handle, address, buffer, n_bytes,
+            am, dw, &count);
+
+    if (status != cvSuccess) {
+        cerr << "CAEN could not read " << hex << address << endl;
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
Block read/write functions were added to `VMEController` and derived classes. `vme2fd` and `OrscEmulator` were modified to use block read/write. The simple echo test appears to work without problems.
