### PR TITLE
Fix oRSC FE SPI Echo Test Printout

### DIFF
--- a/orsc_fe_spi_echo_test/src/lscript.ld
+++ b/orsc_fe_spi_echo_test/src/lscript.ld
@@ -68,7 +68,7 @@ SECTIONS
    KEEP (*(.ctors))
    __CTOR_END__ = .;
    ___CTORS_END___ = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .dtors : {
    __DTOR_LIST__ = .;
@@ -79,7 +79,7 @@ SECTIONS
    KEEP (*(.dtors))
    PROVIDE(__DTOR_END__ = .);
    PROVIDE(___DTORS_END___ = .);
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .rodata : {
    __rodata_start = .;
@@ -87,7 +87,7 @@ SECTIONS
    *(.rodata.*)
    *(.gnu.linkonce.r.*)
    __rodata_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .sdata2 : {
    . = ALIGN(8);
@@ -97,7 +97,7 @@ SECTIONS
    *(.gnu.linkonce.s2.*)
    . = ALIGN(8);
    __sdata2_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .sbss2 : {
    __sbss2_start = .;
@@ -105,7 +105,7 @@ SECTIONS
    *(.sbss2.*)
    *(.gnu.linkonce.sb2.*)
    __sbss2_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .data : {
    . = ALIGN(4);
@@ -114,31 +114,31 @@ SECTIONS
    *(.data.*)
    *(.gnu.linkonce.d.*)
    __data_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .got : {
    *(.got)
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .got1 : {
    *(.got1)
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .got2 : {
    *(.got2)
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .eh_frame : {
    *(.eh_frame)
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .jcr : {
    *(.jcr)
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .gcc_except_table : {
    *(.gcc_except_table)
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .sdata : {
    . = ALIGN(8);
@@ -147,7 +147,7 @@ SECTIONS
    *(.sdata.*)
    *(.gnu.linkonce.s.*)
    __sdata_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .sbss (NOLOAD) : {
    . = ALIGN(4);
@@ -157,7 +157,7 @@ SECTIONS
    *(.gnu.linkonce.sb.*)
    . = ALIGN(8);
    __sbss_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .tdata : {
    __tdata_start = .;
@@ -165,7 +165,7 @@ SECTIONS
    *(.tdata.*)
    *(.gnu.linkonce.td.*)
    __tdata_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .tbss : {
    __tbss_start = .;
@@ -173,7 +173,7 @@ SECTIONS
    *(.tbss.*)
    *(.gnu.linkonce.tb.*)
    __tbss_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .bss (NOLOAD) : {
    . = ALIGN(4);
@@ -184,7 +184,7 @@ SECTIONS
    *(COMMON)
    . = ALIGN(4);
    __bss_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 _SDA_BASE_ = __sdata_start + ((__sbss_end - __sdata_start) / 2 );
 
@@ -198,7 +198,7 @@ _SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
    _heap_start = .;
    . += _HEAP_SIZE;
    _heap_end = .;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 .stack (NOLOAD) : {
    _stack_end = .;
@@ -206,7 +206,7 @@ _SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
    . = ALIGN(8);
    _stack = .;
    __stack = _stack;
-} > axi_bram_ctrl_0_S_AXI_BASEADDR
+} > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
 
 _end = .;
 }

--- a/orsc_fe_spi_echo_test/src/spiecho.c
+++ b/orsc_fe_spi_echo_test/src/spiecho.c
@@ -16,8 +16,7 @@
 
 #include "spi_stream.h"
 
-/*  STDOUT functionality  */
-void print(char *str);
+#include "xil_printf.h"
 
 /*  SPI device driver plumbing  */
 
@@ -64,7 +63,7 @@ int main() {
       DoSpiTransfer, // callback which triggers a SPI transfer
       0);
 
-  print("Master SPI oRSC echo test\n");
+  xil_printf("Master SPI oRSC echo test\n");
 
   int Status;
   XSpi_Config *ConfigPtr;	/* Pointer to Configuration data */
@@ -74,20 +73,20 @@ int main() {
    */
   ConfigPtr = XSpi_LookupConfig(SPI_DEVICE_ID);
   if (ConfigPtr == NULL) {
-    print ("Error: could not lookup SPI configuration\n");
+    xil_printf ("Error: could not lookup SPI configuration\n");
     return XST_DEVICE_NOT_FOUND;
   }
 
   Status = XSpi_CfgInitialize(&SpiInstance, ConfigPtr,
       ConfigPtr->BaseAddress);
   if (Status != XST_SUCCESS) {
-    print("Error: could not initialize the SPI device\n");
+    xil_printf("Error: could not initialize the SPI device\n");
     return XST_FAILURE;
   }
 
   Status = XSpi_SelfTest(&SpiInstance);
   if (Status != XST_SUCCESS) {
-    print("Error: The SPI self test failed.\n");
+    xil_printf("Error: The SPI self test failed.\n");
     return XST_FAILURE;
   }
 
@@ -97,7 +96,7 @@ int main() {
    */
   Status = SpiSetupIntrSystem(&IntcInstance, &SpiInstance, SPI_IRPT_INTR);
   if (Status != XST_SUCCESS) {
-    print("Error: Could not setup interrupt system.\n");
+    xil_printf("Error: Could not setup interrupt system.\n");
     return XST_FAILURE;
   }
 
@@ -153,7 +152,7 @@ static int SpiSetupIntrSystem(XIntc *IntcInstancePtr, XSpi *SpiInstancePtr,
    */
   Status = XIntc_Initialize(IntcInstancePtr, INTC_DEVICE_ID);
   if (Status != XST_SUCCESS) {
-    print("Could not initialize interrupt controller.\n");
+    xil_printf("Could not initialize interrupt controller.\n");
     return XST_FAILURE;
   }
 
@@ -166,7 +165,7 @@ static int SpiSetupIntrSystem(XIntc *IntcInstancePtr, XSpi *SpiInstancePtr,
       (XInterruptHandler) XSpi_InterruptHandler,
       (void *)SpiInstancePtr);
   if (Status != XST_SUCCESS) {
-    print("Could not connect interrupt controller to SPI.\n");
+    xil_printf("Could not connect interrupt controller to SPI.\n");
     return XST_FAILURE;
   }
 
@@ -177,7 +176,7 @@ static int SpiSetupIntrSystem(XIntc *IntcInstancePtr, XSpi *SpiInstancePtr,
    */
   Status = XIntc_Start(IntcInstancePtr, XIN_REAL_MODE);
   if (Status != XST_SUCCESS) {
-    print("Could not enable interrupts.\n");
+    xil_printf("Could not enable interrupts.\n");
     return XST_FAILURE;
   }
 


### PR DESCRIPTION
With these changes, the `orsc_fe_spi_echo_test` does print out to the XMD console.
