### PR TITLE
oRSC BE SPI echo test tracer

### DIFF
--- a/orsc_be_spi_echo_test/Makefile
+++ b/orsc_be_spi_echo_test/Makefile
@@ -8,11 +8,12 @@ IPBUS=$(SOFTIPBUS)
 # In JTAG chain, needed for make upload
 DEVICENR=1
 
-INCLUDES=-I$(IPBUS)/include -I../spistream
+INCLUDES=-I$(IPBUS)/include -I../spistream -I../tracer
 
 # Make a single megalibrary of all user code.
 SRCS=$(wildcard src/*.c) $(wildcard ../spistream/*.c) \
-     $(wildcard $(SOFTIPBUS)/src/*buffer*.c)
+     $(wildcard $(SOFTIPBUS)/src/*buffer*.c) \
+     ../tracer/tracer.c
 
 include ../Makefile
 

--- a/orsc_be_spi_echo_test/Makefile
+++ b/orsc_be_spi_echo_test/Makefile
@@ -19,3 +19,5 @@ include ../Makefile
 
 # No logging
 LOG_LEVEL=0
+DEBUG=-g3
+OPT=-O2

--- a/orsc_be_spi_echo_test/src/lscript.ld
+++ b/orsc_be_spi_echo_test/src/lscript.ld
@@ -11,7 +11,7 @@
 /*******************************************************************/
 
 _STACK_SIZE = DEFINED(_STACK_SIZE) ? _STACK_SIZE : 0x400;
-_HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0x400;
+_HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0xF20;
 
 /* Define Memories in the system */
 

--- a/orsc_be_spi_echo_test/src/spiecho.c
+++ b/orsc_be_spi_echo_test/src/spiecho.c
@@ -19,8 +19,8 @@
 #include "xil_exception.h"
 
 #include "spi_stream.h"
-
 #include "macrologger.h"
+#include "tracer.h"
 
 /*  SPI device driver plumbing  */
 #define SPI_DEVICE_ID		XPAR_SPI_INTERFPGA_DEVICE_ID
@@ -65,6 +65,9 @@ int main() {
 
   LOG_INFO("\n==> main");
 
+  setup_tracer((uint32_t*)0x7FF0, 4);
+  set_trace_flag(0);
+
   // initialize stdout.
   init_platform();
 
@@ -75,6 +78,7 @@ int main() {
       tx_buffer, rx_buffer,
       DoSpiTransfer, // callback which triggers a SPI transfer
       0);
+  set_trace_flag(1);
 
   int Status;
   XSpi_Config *ConfigPtr;	/* Pointer to Configuration data */
@@ -87,6 +91,7 @@ int main() {
     LOG_INFO("Error: lookup conf");
     return XST_DEVICE_NOT_FOUND;
   }
+  set_trace_flag(0xA);
 
   Status = XSpi_CfgInitialize(&SpiInstance, ConfigPtr,
       ConfigPtr->BaseAddress);
@@ -95,6 +100,7 @@ int main() {
     return XST_FAILURE;
   }
   LOG_INFO("SPI init");
+  set_trace_flag(0xB);
 
   Status = XSpi_SelfTest(&SpiInstance);
   if (Status != XST_SUCCESS) {
@@ -102,6 +108,7 @@ int main() {
     return XST_FAILURE;
   }
   LOG_INFO("Selftest");
+  set_trace_flag(0xC);
 
   /*
    * Connect the Spi device to the interrupt subsystem such that
@@ -113,6 +120,7 @@ int main() {
     return XST_FAILURE;
   }
   LOG_INFO("Setup intr");
+  set_trace_flag(0xD);
 
   /*
    * Configure the interrupt service routine
@@ -128,6 +136,8 @@ int main() {
     return XST_FAILURE;
   }
   LOG_INFO("Conf Mstr");
+
+  set_trace_flag(2);
 
   // Go!
   XSpi_Start(&SpiInstance);
@@ -181,6 +191,7 @@ int main() {
       expected_rx++;
       cbuffer_deletefront(rx_buffer, 1);
     }
+    set_trace_flag(successes);
   }
 
   LOG_INFO("Goodbye");


### PR DESCRIPTION
Kill printfs via LOG_LEVEL 0, trace execution using address: 0x7FF0

You can check how far the program gets by stoping the program using xmd and then doing:

```
mrd 0x7FF0
```

which will return 0xC, i.e. it crashes here:

https://github.com/ekfriis/cms-calo-layer1/compare/be-spi-echo?expand=1#diff-92278a98eaea9b7fcd5873f908f5bc6aL107
