### PR TITLE
Use the linker script to create a separate memory area for storing trace info

### DIFF
--- a/orsc_be_spi_echo_test/src/lscript.ld
+++ b/orsc_be_spi_echo_test/src/lscript.ld
@@ -11,14 +11,16 @@
 /*******************************************************************/
 
 _STACK_SIZE = DEFINED(_STACK_SIZE) ? _STACK_SIZE : 0x400;
-_HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0xF20;
+_HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0xF00;
 
 /* Define Memories in the system */
 
 MEMORY
 {
-   microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl : ORIGIN = 0x00000050, LENGTH = 0x00007FB0
+   microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl : ORIGIN = 0x00000050, LENGTH = 0x00007FAC
    axi_bram_ctrl_0_S_AXI_BASEADDR : ORIGIN = 0x10000000, LENGTH = 0x00010000
+   /* memory used for storing flags readout in XMD */
+   tracer_ptr : ORIGIN = 0x00007FFC, LENGTH = 0x3
 }
 
 /* Specify the default entry point to the program */
@@ -207,6 +209,12 @@ _SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
    _stack = .;
    __stack = _stack;
 } > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
+
+.my_tracer_ptr : {
+  __tracer_start = . ;
+    *(.mem_ptr)
+  __tracer_end = . ;
+  } > tracer_ptr
 
 _end = .;
 }

--- a/orsc_be_spi_echo_test/src/spiecho.c
+++ b/orsc_be_spi_echo_test/src/spiecho.c
@@ -65,7 +65,8 @@ int main() {
 
   LOG_INFO("\n==> main");
 
-  setup_tracer((uint32_t*)0x7FF0, 4);
+  extern void *__tracer_start;
+  setup_tracer((uint32_t*)__tracer_start, 4);
   set_trace_flag(0);
 
   // initialize stdout.

--- a/orsc_be_spi_echo_test/src/spiecho.c
+++ b/orsc_be_spi_echo_test/src/spiecho.c
@@ -66,7 +66,7 @@ int main() {
   LOG_INFO("\n==> main");
 
   extern void *__tracer_start;
-  setup_tracer((uint32_t*)__tracer_start, 4);
+  setup_tracer((uint32_t*)__tracer_start, 3);
   set_trace_flag(0);
 
   // initialize stdout.

--- a/orsc_fe_spi_echo_test/src/lscript.ld
+++ b/orsc_fe_spi_echo_test/src/lscript.ld
@@ -17,8 +17,10 @@ _HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0x1000;
 
 MEMORY
 {
-   microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl : ORIGIN = 0x00000050, LENGTH = 0x00007FB0
+   microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl : ORIGIN = 0x00000050, LENGTH = 0x00007FAC
    axi_bram_ctrl_0_S_AXI_BASEADDR : ORIGIN = 0x10000000, LENGTH = 0x00010000
+   /* memory used for storing flags readout in XMD */
+   tracer_ptr : ORIGIN = 0x00007FFC, LENGTH = 0x3
 }
 
 /* Specify the default entry point to the program */
@@ -207,6 +209,13 @@ _SDA2_BASE_ = __sdata2_start + ((__sbss2_end - __sdata2_start) / 2 );
    _stack = .;
    __stack = _stack;
 } > microblaze_0_i_bram_ctrl_microblaze_0_d_bram_ctrl
+
+.my_tracer_ptr : {
+  __tracer_start = . ;
+    *(.mem_ptr)
+  __tracer_end = . ;
+  } > tracer_ptr
+
 
 _end = .;
 }

--- a/orsc_fe_spi_echo_test/src/spiecho.c
+++ b/orsc_fe_spi_echo_test/src/spiecho.c
@@ -68,7 +68,8 @@ int main() {
 
   LOG_INFO("\n==> main");
 
-  setup_tracer((uint32_t*)0x10008000, 4);
+  extern void *__tracer_start;
+  setup_tracer((uint32_t*)__tracer_start, 3);
   set_trace_flag(0);
 
   // initialize stdout.


### PR DESCRIPTION
This makes it so there is no chance that writing to the (previously randomly chosen) memory with the tracer will clobber the stack/heap.
