### PR TITLE
Update VMEStream to Handle New VME Memory Restrictions

### DIFF
--- a/VMEStream/Makefile
+++ b/VMEStream/Makefile
@@ -14,6 +14,11 @@ SRC:=$(wildcard src/vmestream/*.c) \
 	$(SOFTIPBUS)/src/handlers.c \
 	$(SOFTIPBUS)/src/testmembase.c
 
+CSRC:=$(wildcard src/vmestream/*.c) \
+	$(SOFTIPBUS)/src/circular_buffer.c \
+	$(SOFTIPBUS)/src/buffer.c \
+	$(SOFTIPBUS)/src/bytebuffer.c
+
 OBJ:=$(patsubst %.cc,%.o,$(patsubst %.c,%.o,$(SRC)))
 
 LIB=lib/libvmestream.a
@@ -44,13 +49,13 @@ $(LIB) : $(OBJ)
 
 .PHONY : clean tests
 
-tests : $(LIB)
+tests : $(CSRC)
 tests : $(SH_TESTS)
 tests : $(TESTS)
 	@sh ./tests/runtests.sh
 
 tests/%_tests : tests/%_tests.c
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LIB)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(CSRC)
 
 clean :
 	rm -rf lib bin $(OBJ) $(TESTS)

--- a/VMEStream/include/OrscEmulator.h
+++ b/VMEStream/include/OrscEmulator.h
@@ -16,10 +16,12 @@ class OrscEmulator : public VMEController
 {
     protected:
 
-        uint32_t register1; // 0xBEEFCAFE
-        uint32_t register2; // 0xDEADBEEF
-        uint32_t* ram1;      // 0xCAFEBABE
-        uint32_t* ram2;      // 0xFACEFEED
+        uint32_t register1;  // PC_RECV_SIZE
+        uint32_t register2;  // PC_SEND_SIZE
+        uint32_t register3;  // ORSC_RECV_SIZE
+        uint32_t register4;  // ORSC_SEND_SIZE
+        uint32_t* ram1;      // PC2ORSC_DATA
+        uint32_t* ram2;      // ORSC2PC_DATA
 
         VMEStream* stream;
         CircularBuffer* input_buffer;

--- a/VMEStream/include/OrscEmulator.h
+++ b/VMEStream/include/OrscEmulator.h
@@ -16,12 +16,12 @@ class OrscEmulator : public VMEController
 {
     protected:
 
-        uint32_t register1;  // PC_RECV_SIZE
-        uint32_t register2;  // PC_SEND_SIZE
-        uint32_t register3;  // ORSC_RECV_SIZE
-        uint32_t register4;  // ORSC_SEND_SIZE
-        uint32_t* ram1;      // PC2ORSC_DATA
-        uint32_t* ram2;      // ORSC2PC_DATA
+        uint32_t local_recv_size;  // PC_RECV_SIZE
+        uint32_t local_send_size;  // PC_SEND_SIZE
+        uint32_t remote_recv_size;  // ORSC_RECV_SIZE
+        uint32_t remote_send_size;  // ORSC_SEND_SIZE
+        uint32_t* send_data;      // PC2ORSC_DATA
+        uint32_t* recv_data;      // ORSC2PC_DATA
 
         VMEStream* stream;
         CircularBuffer* input_buffer;

--- a/VMEStream/include/VMEStream.h
+++ b/VMEStream/include/VMEStream.h
@@ -11,10 +11,10 @@
 
 
 typedef struct {
-    uint32_t local_send_size;    // How many words are loaded into send_data
-    uint32_t local_recv_size;    // How many words have been read from recv_data
-    uint32_t remote_send_size;   // How many words are loaded into recv_data
-    uint32_t remote_recv_size;   // How many words are read from send_data
+    uint32_t* local_send_size;    // How many words are loaded into send_data
+    uint32_t* local_recv_size;    // How many words have been read from recv_data
+    uint32_t* remote_send_size;   // How many words are loaded into recv_data
+    uint32_t* remote_recv_size;   // How many words are read from send_data
 
     uint32_t* recv_data;         // Recieve buffer (read only)
     uint32_t* send_data;         // Transmit buffer (write only)
@@ -36,10 +36,10 @@ VMEStream *vmestream_initialize_heap(
 VMEStream *vmestream_initialize_mem(
         CircularBuffer *input,
         CircularBuffer *output,
-        uint32_t local_send_size,
-        uint32_t local_recv_size,
-        uint32_t remote_send_size,
-        uint32_t remote_recv_size,
+        uint32_t* local_send_size,
+        uint32_t* local_recv_size,
+        uint32_t* remote_send_size,
+        uint32_t* remote_recv_size,
         uint32_t* recv_data,
         uint32_t* send_data,
         uint32_t MAXRAM);

--- a/VMEStream/include/VMEStream.h
+++ b/VMEStream/include/VMEStream.h
@@ -11,38 +11,45 @@
 
 
 typedef struct {
-    uint32_t *tx_size;          // Number of words in transmit buffer
-    uint32_t *tx_data;          // Transmit buffer
-    uint32_t *rx_size;          // Number of words in recieve buffer
-    uint32_t *rx_data;          // Recieve buffer
-    uint32_t MAXRAM;            // The maximum size (in words) of the VME RAM
+    uint32_t local_send_size;    // How many words are loaded into send_data
+    uint32_t local_recv_size;    // How many words have been read from recv_data
+    uint32_t remote_send_size;   // How many words are loaded into recv_data
+    uint32_t remote_recv_size;   // How many words are read from send_data
+
+    uint32_t* recv_data;         // Recieve buffer (read only)
+    uint32_t* send_data;         // Transmit buffer (write only)
+    uint32_t MAXRAM;             // The maximum size (in words) of the VME RAM
+
     CircularBuffer *input;
     CircularBuffer *output;
 } VMEStream;
 
+
 // Initialize a VMEStream object, allocating transfer/size buffers on the heap
 VMEStream *vmestream_initialize_heap(
-        CircularBuffer *intput,
+        CircularBuffer *input,
         CircularBuffer *output,
         uint32_t MAXRAM);
 
-// Initialize a VMEStream object pointing to existing buffers 
+
+// Initialize a VMEStream object pointing to existing buffers
 VMEStream *vmestream_initialize_mem(
         CircularBuffer *input,
         CircularBuffer *output,
-        uint32_t *tx_size,
-        uint32_t *rx_size,
-        uint32_t *tx_data,
-        uint32_t *rx_data,
+        uint32_t local_send_size,
+        uint32_t local_recv_size,
+        uint32_t remote_send_size,
+        uint32_t remote_recv_size,
+        uint32_t* recv_data,
+        uint32_t* send_data,
         uint32_t MAXRAM);
+        
 
 // Free memory allocated by the vmestream_initialize_heap function.
 void vmestream_destroy_heap(VMEStream *stream);
 
-// Swap data from the circular buffers to the VME transfer RAMs, according to
-// the VMEStream protocol. Calling this will move (if possible) data from
-// stream->input into stream->tx_data, and (if possible) from stream->rx_data
-// to stream->output.
+/** Perform a VMEStream datatransfer
+ */
 int vmestream_transfer_data(VMEStream *stream);
 
 void do_vme_transfer(VMEStream *stream);

--- a/VMEStream/include/VMEStreamAddress.h
+++ b/VMEStream/include/VMEStreamAddress.h
@@ -1,7 +1,24 @@
 /*
  * Central definition of VME addresses used by VMEStream
+ *
+ * MB BASEADDR = 0x10000000
+ * VME BASEADDR for slot 0
+ * 
+ * MB and VME offsets from base address
+ * --MB READS, VME WRITES
+ * --Address Range: 0x0000-0x07FF
+ * 
+ * --MB READS, VME WRITES
+ * --Address Range: 0x0800-0x0FFF
+ * 
+ * --VME READS, MB WRITES
+ * --Address Range: 0x1000-0x17FF
+ * 
+ * --VME READS, MB WRITES
+ * --Address Range: 0x1800-0x1FFF
  */
 
+/*
 #define ORSC_2_PC_SIZE 0x0800
 #define PC_2_ORSC_SIZE 0x0000
 
@@ -9,3 +26,14 @@
 #define PC_2_ORSC_DATA 0x0004
 
 #define VMERAMSIZE 511 // (0x800 - 0x004)/4
+*/
+
+#define PC_RECV_SIZE    0x10000000
+#define PC_SEND_SIZE    0x10000004
+#define PC2ORSC_DATA    0x10000008
+
+#define ORSC_RECV_SIZE  0x10001000
+#define ORSC_SEND_SIZE  0x10001004
+#define ORSC2PC_DATA    0x10001008
+
+#define VMERAMSIZE 510

--- a/VMEStream/src/vme2fd.cc
+++ b/VMEStream/src/vme2fd.cc
@@ -49,25 +49,32 @@ void pc2orsc_server(char* in_pipe, char* out_pipe)
         }
         bytebuffer_del_front(&buf, words2append * sizeof(uint32_t));
 
-        vme->read(ORSC_RECV_SIZE, DATAWIDTH, &stream->remote_recv_size);
-        vme->read(ORSC_SEND_SIZE, DATAWIDTH, &stream->remote_send_size);
-        vme->write(PC_RECV_SIZE, DATAWIDTH, &stream->local_recv_size);
-        vme->write(PC_SEND_SIZE, DATAWIDTH, &stream->local_send_size);
-
-        // send data via VME
-        if (stream->local_send_size > 0 && stream->remote_recv_size == 0) {
-            vme->block_write(PC2ORSC_DATA, DATAWIDTH, stream->send_data, stream->local_send_size * sizeof(uint32_t));
-        }
-
-        // recieve data via VME
-        if (stream->local_recv_size == 0 && stream->remote_send_size > 0) {
-            vme->block_read(ORSC2PC_DATA, DATAWIDTH, stream->recv_data, stream->remote_send_size * sizeof(uint32_t));
-        }
-
+        // update flags w/ VME
+        vme->read(ORSC_RECV_SIZE, DATAWIDTH, stream->remote_recv_size);
+        vme->read(ORSC_SEND_SIZE, DATAWIDTH, stream->remote_send_size);
+        vme->write(PC_RECV_SIZE, DATAWIDTH, stream->local_recv_size);
+        vme->write(PC_SEND_SIZE, DATAWIDTH, stream->local_send_size);
 
         // move data in/out of the buffers and update size values
         vmestream_transfer_data(stream);
 
+        printf("vme2fd\n");
+        printf("  remote_recv_size: %d\n", *(stream->remote_recv_size));
+        printf("  remote_send_size: %d\n", *(stream->remote_send_size));
+        printf("  local_recv_size:  %d\n", *(stream->local_recv_size));
+        printf("  local_send_size:  %d\n", *(stream->local_send_size));
+
+        // send data via VME
+        if (*(stream->local_send_size) > 0) {
+            printf("  Send\n");
+            vme->block_write(PC2ORSC_DATA, DATAWIDTH, stream->send_data, *(stream->local_send_size) * sizeof(uint32_t));
+        }
+
+        // recieve data via VME
+        if (*(stream->remote_send_size) > 0) {
+            printf("  Recieve\n");
+            vme->block_read(ORSC2PC_DATA, DATAWIDTH, stream->recv_data, *(stream->remote_send_size) * sizeof(uint32_t));
+        }
 
         uint32_t recv_words = cbuffer_size(stream->output);
         if (recv_words > 0) {
@@ -75,53 +82,7 @@ void pc2orsc_server(char* in_pipe, char* out_pipe)
         }
 
         vme->doStuff();
-
-        /*
-        // the size of the read buffer will be dynamically resized
-        // as necessary.
-        bytebuffer_read_fd(&buf, fin, READ_BUFFER_SIZE);
-
-        uint32_t words_to_append = MIN(
-            buf.bufsize/sizeof(uint32_t), cbuffer_freespace(stream->input));
-        if (words_to_append > 0) {
-            cbuffer_append(stream->input, buf.buf, words_to_append);
-        }
-        // pop off read words, leaving any fractional words in the input buffer
-        bytebuffer_del_front(&buf, words_to_append * sizeof(uint32_t));
-
-        vmestream_transfer_data(stream);
-
-
-        vme->read(PC_2_ORSC_SIZE, DATAWIDTH, &vme_tx_size);
-
-        if (vme_tx_size == 0 && *(stream->tx_size) > 0) {
-            vme->block_write(PC_2_ORSC_DATA, DATAWIDTH, stream->tx_data,
-                    *(stream->tx_size) * sizeof(uint32_t));
-            vme->write(PC_2_ORSC_SIZE, DATAWIDTH, stream->tx_size);
-            *(stream->tx_size) = 0;
-        }
-
-
-        vme->read(ORSC_2_PC_SIZE, DATAWIDTH, &vme_rx_size);
-
-        if (vme_rx_size > 0 && *(stream->rx_size) == 0) {
-            vme->block_read(ORSC_2_PC_DATA, DATAWIDTH, stream->rx_data,
-                    vme_rx_size * sizeof(uint32_t));
-            *(stream->rx_size) = vme_rx_size;
-            uint32_t zero = 0;
-            vme->write(ORSC_2_PC_SIZE, DATAWIDTH, &zero);
-        }
-
-        vmestream_transfer_data(stream);
-
-        // if stream->ouput has data, then output it
-        uint32_t n_words = cbuffer_size(stream->output);
-        if (n_words > 0) {
-            cbuffer_write_fd(stream->output, fout, n_words);
-        }
-        // Do any desired emulation. In production, this does nothing.
-        vme->doStuff();
-        */
+        printf("\n");
     }
 
     close(fin);

--- a/VMEStream/src/vme2fd.cc
+++ b/VMEStream/src/vme2fd.cc
@@ -57,22 +57,14 @@ void pc2orsc_server(char* in_pipe, char* out_pipe)
 
         // recieve data via VME
         if (*(stream->remote_send_size) > 0) {
-            printf("  Recieve\n");
             vme->block_read(ORSC2PC_DATA, DATAWIDTH, stream->recv_data, *(stream->remote_send_size) * sizeof(uint32_t));
         }
 
         // move data in/out of the buffers and update size values
         vmestream_transfer_data(stream);
 
-        // printf("vme2fd\n");
-        // printf("  remote_recv_size: %d\n", *(stream->remote_recv_size));
-        // printf("  remote_send_size: %d\n", *(stream->remote_send_size));
-        // printf("  local_recv_size:  %d\n", *(stream->local_recv_size));
-        // printf("  local_send_size:  %d\n", *(stream->local_send_size));
-
         // send data via VME
         if (*(stream->local_send_size) > 0) {
-            printf("  Send\n");
             vme->block_write(PC2ORSC_DATA, DATAWIDTH, stream->send_data, *(stream->local_send_size) * sizeof(uint32_t));
         }
 
@@ -82,7 +74,6 @@ void pc2orsc_server(char* in_pipe, char* out_pipe)
         }
 
         vme->doStuff();
-        // printf("\n");
     }
 
     close(fin);

--- a/VMEStream/src/vme2fd.cc
+++ b/VMEStream/src/vme2fd.cc
@@ -55,25 +55,25 @@ void pc2orsc_server(char* in_pipe, char* out_pipe)
         vme->write(PC_RECV_SIZE, DATAWIDTH, stream->local_recv_size);
         vme->write(PC_SEND_SIZE, DATAWIDTH, stream->local_send_size);
 
+        // recieve data via VME
+        if (*(stream->remote_send_size) > 0) {
+            printf("  Recieve\n");
+            vme->block_read(ORSC2PC_DATA, DATAWIDTH, stream->recv_data, *(stream->remote_send_size) * sizeof(uint32_t));
+        }
+
         // move data in/out of the buffers and update size values
         vmestream_transfer_data(stream);
 
-        printf("vme2fd\n");
-        printf("  remote_recv_size: %d\n", *(stream->remote_recv_size));
-        printf("  remote_send_size: %d\n", *(stream->remote_send_size));
-        printf("  local_recv_size:  %d\n", *(stream->local_recv_size));
-        printf("  local_send_size:  %d\n", *(stream->local_send_size));
+        // printf("vme2fd\n");
+        // printf("  remote_recv_size: %d\n", *(stream->remote_recv_size));
+        // printf("  remote_send_size: %d\n", *(stream->remote_send_size));
+        // printf("  local_recv_size:  %d\n", *(stream->local_recv_size));
+        // printf("  local_send_size:  %d\n", *(stream->local_send_size));
 
         // send data via VME
         if (*(stream->local_send_size) > 0) {
             printf("  Send\n");
             vme->block_write(PC2ORSC_DATA, DATAWIDTH, stream->send_data, *(stream->local_send_size) * sizeof(uint32_t));
-        }
-
-        // recieve data via VME
-        if (*(stream->remote_send_size) > 0) {
-            printf("  Recieve\n");
-            vme->block_read(ORSC2PC_DATA, DATAWIDTH, stream->recv_data, *(stream->remote_send_size) * sizeof(uint32_t));
         }
 
         uint32_t recv_words = cbuffer_size(stream->output);
@@ -82,7 +82,7 @@ void pc2orsc_server(char* in_pipe, char* out_pipe)
         }
 
         vme->doStuff();
-        printf("\n");
+        // printf("\n");
     }
 
     close(fin);

--- a/VMEStream/src/vme2fd.cc
+++ b/VMEStream/src/vme2fd.cc
@@ -22,20 +22,14 @@
 
 #define MIN(x, y) ( (x) < (y) ? (x) : (y) )
 
-int main ( int argc, char** argv )
-{
-    int fin;
-    int fout;
 
+void pc2orsc_server(char* in_pipe, char* out_pipe)
+{
     // empty buffer.
     ByteBuffer buf = bytebuffer_ctor(NULL, 0);
 
-    if ( argc != 3 ) {
-        printf("Usage: vme2fd [instream] [outstream]\n");
-        exit(0);
-    }
-    fin  = open(argv[1], O_RDONLY);
-    fout = open(argv[2], O_WRONLY);
+    int fin  = open(in_pipe, O_RDONLY);
+    int fout = open(out_pipe, O_WRONLY);
 
     CircularBuffer *input = cbuffer_new();
     CircularBuffer *output = cbuffer_new();
@@ -130,9 +124,20 @@ int main ( int argc, char** argv )
         */
     }
 
-    close( fin );
-    close( fout );
+    close(fin);
+    close(fout);
     vmestream_destroy_heap(stream);
+}
+
+
+int main (int argc, char** argv)
+{
+    if ( argc != 3 ) {
+        printf("Usage: vme2fd [instream] [outstream]\n");
+        exit(1);
+    }
+
+    pc2orsc_server(argv[1], argv[2]);
 
     return 0;
 }

--- a/VMEStream/src/vmestream/OrscEchoEmulator.cc
+++ b/VMEStream/src/vmestream/OrscEchoEmulator.cc
@@ -7,18 +7,8 @@ OrscEchoEmulator::OrscEchoEmulator() : OrscEmulator() {}
 void
 OrscEchoEmulator::doStuff() {
   // move from local memory into buffers
-  
-        // printf("oRSC before transfer\n");
-        // printf("  remote_recv_size: %d\n", *(stream->remote_recv_size));
-        // printf("  remote_send_size: %d\n", *(stream->remote_send_size));
-        // printf("  local_recv_size:  %d\n", *(stream->local_recv_size));
-        // printf("  local_send_size:  %d\n", *(stream->local_send_size));
   vmestream_transfer_data(stream);
-        // printf("oRSC after transfer\n");
-        // printf("  remote_recv_size: %d\n", *(stream->remote_recv_size));
-        // printf("  remote_send_size: %d\n", *(stream->remote_send_size));
-        // printf("  local_recv_size:  %d\n", *(stream->local_recv_size));
-        // printf("  local_send_size:  %d\n", *(stream->local_send_size));
+
   // now echo the data
   while (cbuffer_size(output_buffer) && cbuffer_freespace(input_buffer)) {
     cbuffer_push_back(input_buffer, cbuffer_pop_front(output_buffer));

--- a/VMEStream/src/vmestream/OrscEchoEmulator.cc
+++ b/VMEStream/src/vmestream/OrscEchoEmulator.cc
@@ -7,7 +7,18 @@ OrscEchoEmulator::OrscEchoEmulator() : OrscEmulator() {}
 void
 OrscEchoEmulator::doStuff() {
   // move from local memory into buffers
+  
+        // printf("oRSC before transfer\n");
+        // printf("  remote_recv_size: %d\n", *(stream->remote_recv_size));
+        // printf("  remote_send_size: %d\n", *(stream->remote_send_size));
+        // printf("  local_recv_size:  %d\n", *(stream->local_recv_size));
+        // printf("  local_send_size:  %d\n", *(stream->local_send_size));
   vmestream_transfer_data(stream);
+        // printf("oRSC after transfer\n");
+        // printf("  remote_recv_size: %d\n", *(stream->remote_recv_size));
+        // printf("  remote_send_size: %d\n", *(stream->remote_send_size));
+        // printf("  local_recv_size:  %d\n", *(stream->local_recv_size));
+        // printf("  local_send_size:  %d\n", *(stream->local_send_size));
   // now echo the data
   while (cbuffer_size(output_buffer) && cbuffer_freespace(input_buffer)) {
     cbuffer_push_back(input_buffer, cbuffer_pop_front(output_buffer));

--- a/VMEStream/src/vmestream/OrscEmulator.cc
+++ b/VMEStream/src/vmestream/OrscEmulator.cc
@@ -8,6 +8,8 @@ OrscEmulator::OrscEmulator()
 {
     register1 = 0;
     register2 = 0;
+    register3 = 0;
+    register4 = 0;
     ram1      = (uint32_t*) malloc(VMERAMSIZE * sizeof(uint32_t));
     ram2      = (uint32_t*) malloc(VMERAMSIZE * sizeof(uint32_t));
 
@@ -18,10 +20,12 @@ OrscEmulator::OrscEmulator()
     stream = vmestream_initialize_mem(
             input_buffer,
             output_buffer,
-            &register2,
-            &register1,
-            ram2,
-            ram1,
+            register3,      // local_send_size
+            register4,      // local_recv_size
+            register1,      // remote_send_size
+            register2,      // remote_recv_size
+            ram1,           // recv_data
+            ram2,           // send_data
             VMERAMSIZE);
 }
 
@@ -43,15 +47,16 @@ bool
 OrscEmulator::read(unsigned long address, size_t size, void* value)
 {
     switch(address) {
-        case PC_2_ORSC_SIZE:
+        case ORSC_RECV_SIZE:
             assert(size == 4);
-            memcpy(value, &register1, sizeof(uint32_t));
+            memcpy(value, &register3, sizeof(uint32_t));
             break;
-        case ORSC_2_PC_SIZE:
+        case ORSC_SEND_SIZE:
             assert(size == 4);
-            memcpy(value, &register2, sizeof(uint32_t));
+            memcpy(value, &register4, sizeof(uint32_t));
             break;
         default:
+            exit(10);
             return 0;
     }
     return 1;
@@ -65,15 +70,16 @@ bool
 OrscEmulator::write(unsigned long address, size_t size, void* value)
 {
     switch(address) {
-        case PC_2_ORSC_SIZE:
+        case PC_RECV_SIZE:
             assert(size == 4);
             memcpy(&register1, value, sizeof(uint32_t));
             break;
-        case ORSC_2_PC_SIZE:
+        case PC_SEND_SIZE:
             assert(size == 4);
             memcpy(&register2, value, sizeof(uint32_t));
             break;
         default:
+            exit(11);
             return 0;
     }
     return 1;
@@ -101,11 +107,7 @@ OrscEmulator::block_read(uint32_t address, size_t datawidth,
         void* buffer, size_t n_bytes)
 {
     switch(address) {
-        case PC_2_ORSC_DATA:
-            assert(datawidth == 4);
-            memcpy(buffer, ram1, n_bytes);
-            break;
-        case ORSC_2_PC_DATA:
+        case ORSC2PC_DATA:
             assert(datawidth == 4);
             memcpy(buffer, ram2, n_bytes);
             break;
@@ -120,13 +122,9 @@ OrscEmulator::block_write(uint32_t address, size_t datawidth,
         void* buffer, size_t n_bytes)
 {
     switch(address) {
-        case PC_2_ORSC_DATA:
+        case PC2ORSC_DATA:
             assert(datawidth == 4);
             memcpy(ram1, buffer, n_bytes);
-            break;
-        case ORSC_2_PC_DATA:
-            assert(datawidth == 4);
-            memcpy(ram2, buffer, n_bytes);
             break;
         default:
             return 0;

--- a/VMEStream/src/vmestream/VMEStream_PC.c
+++ b/VMEStream/src/vmestream/VMEStream_PC.c
@@ -17,8 +17,8 @@ VMEStream *vmestream_initialize_heap(
     stream->remote_send_size = 0;
     stream->remote_recv_size = 0;
 
-    stream->recv_data = (uint32_t*)malloc(sizeof(MAXRAM));
-    stream->send_data = (uint32_t*)malloc(sizeof(MAXRAM));
+    stream->recv_data = (uint32_t*)calloc(MAXRAM, sizeof(uint32_t));
+    stream->send_data = (uint32_t*)calloc(MAXRAM, sizeof(uint32_t));
 
     stream->MAXRAM = MAXRAM;
 

--- a/VMEStream/tests/VMEStream_tests.c
+++ b/VMEStream/tests/VMEStream_tests.c
@@ -96,149 +96,68 @@ static char* test_ram1()
 }
 
 
+static char* test_ram2()
+{
+    // --------------
+    // Setup
+    // --------------
+    CircularBuffer* pc_input    = cbuffer_new();
+    CircularBuffer* pc_output   = cbuffer_new();
+    CircularBuffer* orsc_input  = cbuffer_new();
+    CircularBuffer* orsc_output = cbuffer_new();
+
+    VMEStream *pc_stream = vmestream_initialize_heap(pc_input, pc_output, 2);
+
+    VMEStream *orsc_stream = malloc(sizeof(VMEStream));
+    orsc_stream->input              = orsc_input;
+    orsc_stream->output             = orsc_output;
+    orsc_stream->local_send_size    = pc_stream->remote_send_size;
+    orsc_stream->local_recv_size    = pc_stream->remote_recv_size;
+    orsc_stream->remote_send_size   = pc_stream->local_send_size;
+    orsc_stream->remote_recv_size   = pc_stream->local_recv_size;
+    orsc_stream->recv_data          = pc_stream->send_data;
+    orsc_stream->send_data          = pc_stream->recv_data;
+    orsc_stream->MAXRAM             = pc_stream->MAXRAM;
+
+
+    cbuffer_push_back(pc_input, 0xDEADBEEF);
+    cbuffer_push_back(orsc_input, 0xBEEFCAFE);
+
+    vmestream_transfer_data(pc_stream);
+
+    vmestream_transfer_data(orsc_stream);
+    vmestream_transfer_data(pc_stream);
+
+    mu_assert("Error: pc_input not empty", cbuffer_size(pc_input) == 0);
+    mu_assert("Error: orsc_input not empty", cbuffer_size(orsc_input) == 0);
+
+    mu_assert("Error: orsc_output.pop != DEADBEEF", cbuffer_pop_front(orsc_output));
+    mu_assert("Error: pc_output.pop != BEEFCAFE", cbuffer_pop_front(pc_output));
+
+    mu_assert("Error: pc_output not empty", cbuffer_size(pc_output) == 0);
+    mu_assert("Error: orsc_output not empty", cbuffer_size(orsc_output) == 0);
+
+    // --------------
+    // Tear-Down
+    // --------------
+    vmestream_destroy_heap(pc_stream);
+    free(orsc_stream);
+    cbuffer_free(pc_input);
+    cbuffer_free(orsc_input);
+    cbuffer_free(pc_output);
+    cbuffer_free(orsc_output);
+
+    return 0;
+}
+
+
 static char* all_tests()
 {
     mu_run_test(test_ram1);
+    mu_run_test(test_ram2);
 
     return 0;
 }
-    
-
-/*
-static char *test_ram1()
-{
-    // local application buffers
-    CircularBuffer *tx1 = cbuffer_new();
-    CircularBuffer *rx1 = cbuffer_new();
-    CircularBuffer *tx2 = cbuffer_new();
-    CircularBuffer *rx2 = cbuffer_new();
-
-    VMEStream *test1 = vmestream_initialize(tx1, rx1, 1);
-    VMEStream *test2 = malloc(sizeof(VMEStream));
-    test2->input = tx2;
-    test2->output = rx2;
-
-    test2->rx_size = test1->tx_size;
-    test2->tx_size = test1->rx_size;
-    test2->rx_data = test1->tx_data;
-    test2->tx_data = test1->rx_data;
-    test2->MAXRAM  = test1->MAXRAM;
-
-    for (unsigned int i = 0; i < 20; ++i) {
-        // put some output data on host #1
-        cbuffer_push_back(tx1, 0xDEADBEEF + i);
-        // put some output data on host #2
-        cbuffer_push_back(tx2, 0xBEEFCAFE + i);
-    }
-
-    // do a transfer
-    vmestream_transfer_data(test1); // step 1 
-    vmestream_transfer_data(test2); // step 2
-
-    // host #2 has received data, since host #1 filled it's TX buffer in step 1
-    // and host #2 can read it out in step 2
-    mu_assert("Error: 0xDEADBEEF != rx2.pop", 0xDEADBEEF == cbuffer_pop_front(rx2));
-
-    vmestream_transfer_data(test1); // step 3
-    // now host #1 can read the data loaded by host #2 in step 2
-    mu_assert("Error: 0xBEEFCAFE != rx1.pop", 0xBEEFCAFE == cbuffer_pop_front(rx1));
-
-    // do another transfer
-    vmestream_transfer_data(test2);
-    vmestream_transfer_data(test1);
-
-    mu_assert("Error: 0xBEEFCAFE+1 != rx1.pop", 0xBEEFCAFE + 1 == cbuffer_pop_front(rx1));
-    mu_assert("Error: 0xDEADBEEF+1 != rx2.pop", 0xDEADBEEF + 1 == cbuffer_pop_front(rx2));
-
-    // We have consumed all received data (via pop).  There is a word of 
-    // data in limbo for host #1
-    mu_assert("Error: 0 != rx1.size", 0 == cbuffer_size(rx1));
-    mu_assert("Error: 0 != rx2.size", 0 == cbuffer_size(rx2));
-    mu_assert("Error: 17 != tx1.size", 17 == cbuffer_size(tx1));
-    mu_assert("Error: 18 != tx2.size", 18 == cbuffer_size(tx2));
-
-    // call transfer on #1 twice in a row.  Since it's still waiting for
-    // #2 to read the data, nothing happens.
-    vmestream_transfer_data(test1);
-    mu_assert("Error: 0 != rx1.size", 0 == cbuffer_size(rx1));
-    mu_assert("Error: 0 != rx2.size", 0 == cbuffer_size(rx2));
-    mu_assert("Error: 17 != tx1.size", 17 == cbuffer_size(tx1));
-    mu_assert("Error: 18 != tx2.size", 18 == cbuffer_size(tx2));
-
-    // #2 receives limbo data, puts one of it's words in limbo.
-    vmestream_transfer_data(test2);
-    mu_assert("Error: 0 != rx1.size", 0 == cbuffer_size(rx1));
-    mu_assert("Error: 1 != rx2.size", 1 == cbuffer_size(rx2));
-    mu_assert("Error: 17 != tx1.size", 17 == cbuffer_size(tx1));
-    mu_assert("Error: 17 != tx2.size", 17 == cbuffer_size(tx2));
-
-
-    // free memory
-    vmestream_destroy(test1);
-    free(test2);
-    cbuffer_free(tx1);
-    cbuffer_free(rx1);
-    cbuffer_free(tx2);
-    cbuffer_free(rx2);
-
-    return 0;
-}
-*/
-
-
-/**
- * Push less data to the buffers than we have RAM available
- */
-/*
-static char *test_ram2()
-{
-    // local application buffers
-    CircularBuffer *tx1 = cbuffer_new();
-    CircularBuffer *rx1 = cbuffer_new();
-    CircularBuffer *tx2 = cbuffer_new();
-    CircularBuffer *rx2 = cbuffer_new();
-
-    VMEStream *test1 = vmestream_initialize(tx1, rx1, 2);
-    VMEStream *test2 = malloc(sizeof(VMEStream));
-    test2->input = tx2;
-    test2->output = rx2;
-
-    test2->rx_size = test1->tx_size;
-    test2->tx_size = test1->rx_size;
-    test2->rx_data = test1->tx_data;
-    test2->tx_data = test1->rx_data;
-    test2->MAXRAM  = test1->MAXRAM;
-
-    // place only one word on the buffers
-    cbuffer_push_back(tx1, 0xDEADBEEF);
-    // put some output data on host #2
-    cbuffer_push_back(tx2, 0xBEEFCAFE);
-
-    vmestream_transfer_data(test1);
-    vmestream_transfer_data(test2);
-    vmestream_transfer_data(test1);
-
-    mu_assert("Error: tx1 not empty", 0 == cbuffer_size(tx1));
-    mu_assert("Error: tx2 not empty", 0 == cbuffer_size(tx2));
-
-    mu_assert("Error: 0xDEADBEEF != rx2.pop", 0xDEADBEEF == cbuffer_pop_front(rx2));
-    mu_assert("Error: 0xBEEFCAFE != rx1.pop", 0xBEEFCAFE == cbuffer_pop_front(rx1));
-
-    mu_assert("Error: rx2 not empty", 0 == cbuffer_size(rx2));
-    mu_assert("Error: rx1 not empty", 0 == cbuffer_size(rx1));
-
-
-    // free memory
-    vmestream_destroy(test1);
-    free(test2);
-    cbuffer_free(tx1);
-    cbuffer_free(rx1);
-    cbuffer_free(tx2);
-    cbuffer_free(rx2);
-
-    return 0;
-}
-*/
 
 
 /**
@@ -320,16 +239,6 @@ static char *test_buf()
     cbuffer_free(tx2);
     cbuffer_free(rx2);
 
-    return 0;
-}
-*/
-
-/*
-static char *all_tests()
-{
-    mu_run_test(test_ram1);
-    mu_run_test(test_ram2);
-    mu_run_test(test_buf);
     return 0;
 }
 */

--- a/VMEStream/tests/VMEStream_tests.c
+++ b/VMEStream/tests/VMEStream_tests.c
@@ -9,109 +9,99 @@
 int tests_run = 0;
 
 
-static char* test_transfer()
+static char* test_ram1()
 {
-    CircularBuffer *input = cbuffer_new();
-    CircularBuffer *output = cbuffer_new();
+    CircularBuffer* pc_input    = cbuffer_new();
+    CircularBuffer* pc_output   = cbuffer_new();
+    CircularBuffer* orsc_input  = cbuffer_new();
+    CircularBuffer* orsc_output = cbuffer_new();
 
-    VMEStream* stream = vmestream_initialize_heap(input, output, 1);
+    VMEStream *pc_stream = vmestream_initialize_heap(pc_input, pc_output, 1);
 
-    cbuffer_push_back(input, 0xBEEFCAFE);
+    VMEStream *orsc_stream = malloc(sizeof(VMEStream));
+    orsc_stream->input              = orsc_input;
+    orsc_stream->output             = orsc_output;
+    orsc_stream->local_send_size    = pc_stream->remote_send_size;
+    orsc_stream->local_recv_size    = pc_stream->remote_recv_size;
+    orsc_stream->remote_send_size   = pc_stream->local_send_size;
+    orsc_stream->remote_recv_size   = pc_stream->local_recv_size;
+    orsc_stream->recv_data          = pc_stream->send_data;
+    orsc_stream->send_data          = pc_stream->recv_data;
+    orsc_stream->MAXRAM             = pc_stream->MAXRAM;
 
-    vmestream_transfer_data(stream);
-
-    assert(stream->local_send_size == 1);
-    assert(stream->local_recv_size == 0);
-    assert(stream->remote_send_size == 0);
-    assert(stream->remote_recv_size == 0);
-
-    assert(stream->send_data[0] == 0xBEEFCAFE);
-
-    stream->recv_data[0] = 0xDEADBEEF;
-    stream->remote_send_size = 1;
-
-    vmestream_transfer_data(stream);
-
-    assert(stream->local_send_size == 1);
-    assert(stream->local_recv_size == 1);
-    assert(stream->remote_send_size == 1);
-    assert(stream->remote_recv_size == 0);
-
-    assert(cbuffer_pop_front(output) == 0xDEADBEEF);
-
-    // clean up heap
-    cbuffer_free(input);
-    cbuffer_free(output);
-    vmestream_destroy_heap(stream);
-
-    return 0;
-}
-
-
-void vme_transfer(VMEStream* stream1, VMEStream* stream2)
-{
-    stream2->remote_send_size = stream1->local_send_size;
-    if (stream1->local_send_size > 0) {
-        memcpy(stream2->recv_data, stream1->send_data,
-                stream1->local_send_size * sizeof(uint32_t));
+    for (uint32_t i = 0; i < 20; ++i) {
+        cbuffer_push_back(pc_input, 0xDEADBEEF + i);
+        cbuffer_push_back(orsc_input, 0xBEEFCAFE + i);
     }
 
-    stream1->remote_send_size = stream2->local_send_size;
-    if (stream2->local_send_size > 0) {
-        memcpy(stream1->recv_data, stream2->send_data,
-                stream2->local_send_size * sizeof(uint32_t));
-    }
-
-    stream1->remote_recv_size = stream2->local_recv_size;
-    stream2->remote_recv_size = stream1->local_recv_size;
-}
-
-
-static char* test_echo()
-{
-    CircularBuffer *pc_input = cbuffer_new();
-    CircularBuffer *pc_output = cbuffer_new();
-    CircularBuffer *orsc_input = cbuffer_new();
-    CircularBuffer *orsc_output = cbuffer_new();
-
-    VMEStream* pc_stream = vmestream_initialize_heap(pc_input, pc_output, 512);
-    VMEStream* orsc_stream = vmestream_initialize_heap(orsc_input, orsc_output, 512);
-
-    cbuffer_push_back(pc_input, 0xDEADBEEF);
-    cbuffer_push_back(pc_input, 0xCAFEBABE);
-    cbuffer_push_back(orsc_input, 0xBEEFCAFE);
-    cbuffer_push_back(orsc_input, 0xBEEFBEEF);
-
-    vmestream_transfer_data(pc_stream);
-    vmestream_transfer_data(orsc_stream);
-
-    assert(cbuffer_size(pc_input) == 0);
-    assert(cbuffer_size(orsc_input) == 0);
-
-    vme_transfer(pc_stream, orsc_stream);
+    // initial transfer
     vmestream_transfer_data(pc_stream);
 
-    vme_transfer(pc_stream, orsc_stream);
+    // transfer data
     vmestream_transfer_data(orsc_stream);
+    vmestream_transfer_data(pc_stream);
 
-    assert(cbuffer_pop_front(pc_output) == 0xBEEFCAFE);
-    assert(cbuffer_pop_front(pc_output) == 0xBEEFBEEF);
-    assert(cbuffer_pop_front(orsc_output) == 0xDEADBEEF);
-    assert(cbuffer_pop_front(orsc_output) == 0xCAFEBABE);
+    mu_assert("Error: orsc_output.pop != DEADBEEF", cbuffer_pop_front(orsc_output) == 0xDEADBEEF);
+    mu_assert("Error: pc_output.pop != BEEFCAFE", cbuffer_pop_front(pc_output) == 0xBEEFCAFE);
 
+    // extra transfer is needed to reset the size registers
+    // to zero to prepare for another transfer
+    vmestream_transfer_data(orsc_stream);
+    vmestream_transfer_data(pc_stream);
 
-    // Clean up the heap
+    // transfer data
+    vmestream_transfer_data(orsc_stream);
+    vmestream_transfer_data(pc_stream);
+
+    mu_assert("Error: orsc_output.pop != DEADBEEF + 1", cbuffer_pop_front(orsc_output) == 0xDEADBEEF + 1);
+    mu_assert("Error: pc_output.pop != BEEFCAFE + 1", cbuffer_pop_front(pc_output) == 0xBEEFCAFE + 1);
+
+    /*
+    printf("pc_output.size: %d\n", cbuffer_size(pc_output));
+    printf("orsc_output.size: %d\n", cbuffer_size(orsc_output));
+    printf("pc_input.size: %d\n", cbuffer_size(pc_input));
+    printf("orsc_input.size: %d\n", cbuffer_size(orsc_input));
+    */
+
+    mu_assert("Error: pc_output.size != 0", cbuffer_size(pc_output) == 0);
+    mu_assert("Error: orsc_output.size != 0", cbuffer_size(orsc_output) == 0);
+    mu_assert("Error: pc_input.size != 18", cbuffer_size(pc_input) == 18);
+    mu_assert("Error: orsc_input.size != 18", cbuffer_size(orsc_input) == 18);
+
+    // transfer on pc_stream 2x in a row. Nothing should happen.
+    vmestream_transfer_data(pc_stream);
+    mu_assert("Error: pc_output.size != 0", cbuffer_size(pc_output) == 0);
+    mu_assert("Error: orsc_output.size != 0", cbuffer_size(orsc_output) == 0);
+    mu_assert("Error: pc_input.size != 18", cbuffer_size(pc_input) == 18);
+    mu_assert("Error: orsc_input.size != 18", cbuffer_size(orsc_input) == 18);
+
+    // reset
+    vmestream_transfer_data(orsc_stream);
+    vmestream_transfer_data(pc_stream);
+
+    vmestream_transfer_data(orsc_stream);
+    mu_assert("Error: pc_output.size != 0", cbuffer_size(pc_output) == 0);
+    mu_assert("Error: orsc_output.size != 1", cbuffer_size(orsc_output) == 1);
+    mu_assert("Error: pc_input.size != 17", cbuffer_size(pc_input) == 17);
+    mu_assert("Error: orsc_input.size != 17", cbuffer_size(orsc_input) == 17);
+
+    vmestream_destroy_heap(pc_stream);
+    free(orsc_stream);
     cbuffer_free(pc_input);
     cbuffer_free(orsc_input);
     cbuffer_free(pc_output);
     cbuffer_free(orsc_output);
 
-    vmestream_destroy_heap(pc_stream);
-    vmestream_destroy_heap(orsc_stream);
-
     return 0;
 }
 
+
+static char* all_tests()
+{
+    mu_run_test(test_ram1);
+
+    return 0;
+}
     
 
 /*
@@ -345,15 +335,6 @@ static char *all_tests()
 */
 
 
-static char* all_tests()
-{
-    mu_run_test(test_transfer);
-    mu_run_test(test_echo);
-
-    return 0;
-}
-
-
 int main(int argc, char *argv[])
 {
     char *result = all_tests();
@@ -361,6 +342,7 @@ int main(int argc, char *argv[])
         printf("%s\n", result);
     }
     else {
+        printf("Tests run: %d\n", tests_run);
         printf("ALL TESTS PASSED\n");
     }
 

--- a/VMEStream/tests/runtests.sh
+++ b/VMEStream/tests/runtests.sh
@@ -2,7 +2,7 @@ echo "------------------"
 echo "Running Unit Tests"
 echo "------------------"
 
-for i in tests/*_tests tests/*_tests.sh
+for i in tests/*_tests #tests/*_tests.sh
 do
     if [ -f $i ]
     then


### PR DESCRIPTION
This is a refactoring of VMEStream to handle the following VME memory definitions and read/write restrictions:

```
MB BASEADDR = 0x10000000
VME BASEADDR for slot 0

MB and VME offsets from base address
--MB READS, VME WRITES
--Address Range: 0x0000-0x07FF

--MB READS, VME WRITES
--Address Range: 0x0800-0x0FFF

--VME READS, MB WRITES
--Address Range: 0x1000-0x17FF

--VME READS, MB WRITES
--Address Range: 0x1800-0x1FFF
```

The local "OrscEchoEmulator" test does work with this PR. Echo test needs to be run on the hardware.
